### PR TITLE
Read ssl_verify and timeout values from the config file

### DIFF
--- a/src/mailcow/__init__.py
+++ b/src/mailcow/__init__.py
@@ -17,7 +17,7 @@ from mailcow.utils import (
     getOpenApiParameters,
     getOpenApiProperties, validate_response)
 import yaml
-
+import urllib3
 
 class MailCow:
     '''
@@ -62,6 +62,8 @@ class MailCow:
         self.url = kwargs.get('url', cfg[self.server]['url'])
         self.token = kwargs.get('token', cfg[self.server]['token'])
         self.ssl_verify = kwargs.get('ssl_verify', cfg['defaults'].get('ssl_verify', cfg[self.server].get('ssl_verify', f'{SSL_VERIFY}'))).lower() not in ["false", "no", "f"]
+        if not self.ssl_verify:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.timeout = int(kwargs.get('timeout', cfg['defaults'].get('timeout', cfg[self.server].get('timeout', f'{SSL_TIMEOUT}'))))
         self.data = None
         self.json = None

--- a/src/mailcow/__init__.py
+++ b/src/mailcow/__init__.py
@@ -61,8 +61,8 @@ class MailCow:
         self.server = kwargs.get('server', cfg['defaults']['server'])
         self.url = kwargs.get('url', cfg[self.server]['url'])
         self.token = kwargs.get('token', cfg[self.server]['token'])
-        self.ssl_verify = kwargs.get('ssl_verify', SSL_VERIFY)
-        self.timeout = kwargs.get('timeout', SSL_TIMEOUT)
+        self.ssl_verify = kwargs.get('ssl_verify', cfg['defaults'].get('ssl_verify', cfg[self.server].get('ssl_verify', f'{SSL_VERIFY}'))).lower() not in ["false", "no", "f"]
+        self.timeout = int(kwargs.get('timeout', cfg['defaults'].get('timeout', cfg[self.server].get('timeout', f'{SSL_TIMEOUT}'))))
         self.data = None
         self.json = None
 


### PR DESCRIPTION
Currently, `ssl_verify` and `timeout` are being read only from the `globals` constants. Read them from the config file, using `globals` if the config file does not include the setting.
When reading `ssl_verify` from the config file, treat the case-insensitive values "false", "no" and "f" as `False`; treat all other values as `True`.
When reading `timeout` from the config file, assume Integer values.

When using `ssl_verify = False`, suppress warnings about self-signed (or otherwise untrusted or invalid certificates) when connecting.